### PR TITLE
Update Readme.md with more dependencies.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,5 @@
 # Requirements
-    npm install browserify, babelify, handlebars, jquery, moment, uglifyjs
+    npm install browserify babelify handlebars jquery moment uglifyjs snuownd babelify-es6-polyfill babel-preset-es2015
 
 # Compilation of bundle.js
-    browserify js/app.js -t babelify | uglifyjs > bundle.js
+    browserify js/app.js | uglifyjs > bundle.js

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+	"browserify" : {
+		"transform" : [
+			[
+				"babelify", {
+					"presets" : [ "es2015" ]
+				}
+			]
+		]
+	}
+}


### PR DESCRIPTION
This also moves the `-t babelify` bits to `package.json` so that the
`es2015` presets can be specified. Technically that could go into the
`browserify` bits, but eh.

A future improvement can be to add the dependencies to `package.json` but
I'm super unfamiliar with nodejs so I'll leave that for someone else
:heart: