### PR TITLE
Add dependencies to package.json

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,5 @@
 # Requirements
-    npm install browserify babelify handlebars jquery moment uglifyjs snuownd babelify-es6-polyfill babel-preset-es2015
+    npm install
 
 # Compilation of bundle.js
-    browserify js/app.js | uglifyjs > bundle.js
+    npm run build

--- a/package.json
+++ b/package.json
@@ -1,11 +1,28 @@
 {
-	"browserify" : {
-		"transform" : [
-			[
-				"babelify", {
-					"presets" : [ "es2015" ]
-				}
-			]
-		]
-	}
+  "scripts": {
+    "build": "browserify js/app.js | uglifyjs > bundle.js"
+  },
+  "devDependencies": {
+    "babel-preset-es2015": "^6.22.0",
+    "babelify": "^7.3.0",
+    "babelify-es6-polyfill": "^1.0.4",
+    "browserify": "^14.0.0",
+    "handlebars": "^4.0.6",
+    "jquery": "^3.1.1",
+    "moment": "^2.17.1",
+    "snuownd": "^1.1.0",
+    "uglifyjs": "^2.4.10"
+  },
+  "browserify": {
+    "transform": [
+      [
+        "babelify",
+        {
+          "presets": [
+            "es2015"
+          ]
+        }
+      ]
+    ]
+  }
 }


### PR DESCRIPTION
This adds all the dependencies from the Readme to the package.json, so all you need to install them is `npm install` now. I also added a build script `npm run build` to run browserify + uglify and updated the Readme.

Follow up on #6, because @lye was too lazy to add `--save-dev` to the `npm install […]` script 😛 .